### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+# Runs Rustfmt and Clippy on pull requests.
+# These tests occur when creating pull requests to any branch.
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dependency caching
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      
+      - name: Rust toolchain installation
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+      
+      - name: Code formatting (rustfmt)
+        run: cargo fmt -- --check
+      
+      - name: Code suggestions and improvements (clippy)
+        run: cargo clippy -- -D clippy::all
+      
+      # Uncomment to enable unit testing
+      #- name: Unit tests
+      #  run: cargo test
+


### PR DESCRIPTION
This PR adds Continuous Integration to the project:

- Adds automated running for any pull request on any branch;
- Runs `rustfmt` for the entire project;
- Runs `clippy` for the entire project;
- Adds recipe for unit testing as well (though it is commented for now).

I've tested the `rustfmt` and `clippy` locally and both are going to fail on the `main` branch, though, but it is safe to merge anyway. 